### PR TITLE
Iteration exponents caused an overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.idea


### PR DESCRIPTION
The calculation of iteration count was limited to 14 bits.

The theoretical limit of iteration count is 2e13 that fits into 45 bits only, but `u32` count allows most practical use-cases for now.

Before this fix, iteration exponent above 2 was actually faster than 0. Also, above 11 a panic was caused, because the iteration count became 0.