### PR TITLE
Giving back requested number of splits even if threshold is 1

### DIFF
--- a/src/shamir/splitter.rs
+++ b/src/shamir/splitter.rs
@@ -114,11 +114,13 @@ impl Splitter {
 		let mut shares = vec![];
 		// if the threshold is 1, then the digest of the shared secret is not used
 		if threshold == 1 {
-			let mut s = proto_share.clone();
-			s.member_index = 0;
-			s.member_threshold = threshold;
-			s.share_value = shared_secret.to_owned();
-			shares.push(s);
+			for i in 0..share_count {
+				let mut s = proto_share.clone();
+				s.member_index = i;
+				s.member_threshold = threshold;
+				s.share_value = shared_secret.to_owned();
+				shares.push(s);
+			}
 			return Ok(shares);
 		}
 

--- a/src/util/encrypt.rs
+++ b/src/util/encrypt.rs
@@ -195,8 +195,6 @@ mod tests {
 	use super::*;
 	use rand::{thread_rng, Rng};
 
-	use crate::error::Error;
-
 	fn roundtrip_test(secret: Vec<u8>, passphrase: &str, identifier: u16, iteration_exponent: u8) {
 		let enc = MasterSecretEnc::default();
 		println!("master_secret: {:?}", secret);


### PR DESCRIPTION
The [SLIP-0039 specification](https://github.com/satoshilabs/slips/blob/master/slip-0039.md#design-rationale) discusses the case when the member-shares are using a 1-of-m split, then m should be 1 (still allows it to be more than 1, but that is reasonably impractical).

The specification does not discuss though the case when the group threshold is 1 and there are more than 1 groups with different member splits. As [a bug report](https://github.com/Internet-of-People/slip39-rust/issues/3) suggested, this seems to be a valid use-case.

This pull request makes sure the SSS code gives back the same number of shares as it is requested. Maybe an additional validation of group specifications is missing from the `shamir::generate_mnemonics` function, but I thought it is not the responsibility of the `Splitter` struct to change the number of group shares returned, so I copied the unsplit secret multiple times into the output.