### PR TITLE
Release 0.0.2 on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sssmc39"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Yeastplume <yeastplume@protonmail.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
@yeastplume Because of the intentional security limitations of the `cargo` tool I cannot release a new version of `slip39` on crates.io unless a newer version of your crate is released. Could you please merge this to master, tag it and publish on crates.io?